### PR TITLE
Implement caching mechanism for deep populate

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,75 +1,79 @@
-# @fourlights/strapi-plugin-deep-populate
+# Strapi Deep Populate Plugin
 
 [![npm version](https://badge.fury.io/js/@fourlights%2Fstrapi-plugin-deep-populate.svg)](https://badge.fury.io/js/@fourlights%2Fstrapi-plugin-deep-populate)
 
-TL/DR: with this plugin `populate: '*'` will return all nested properties.
+A Strapi v5 plugin that automatically populates all nested relations in a single request using `populate: '*'`.
 
-This Strapi v5 plugin provides a simple way of retrieving all nested objects in a single request.
-It does this by traversing the schema and comparing that to the actual retrieved document(s).
-Only relations that are actually set will be populated.
+## Features
+
+- Automatically resolves and populates all nested relations
+- Supports all relation types including dynamic zones
+- Handles circular references and edge cases
+- Includes caching for improved performance
+- Honors `populateCreatorFields` setting
+
+## Installation
+
+```bash
+npm install @fourlights/strapi-plugin-deep-populate
+```
 
 ## Usage
 
-Relevant setting: `deep-populate.augmentPopulateStar` = `true` (default)
-```ts
-// Option 1: handle `populate: '*'` directly
-// e.g. page -> section -> blocks -> column -> component
-const document = await strapi.documents("api.page.page").findOne({ document: 'xyz', populate: '*' })
-// this will return all nested objects.
+Enable deep population in your Strapi config:
+
+```js
+// config/plugins.js
+module.exports = ({ env }) => ({
+  'deep-populate': {
+    augmentPopulateStar: true, // default
+    cachePopulate: true // default
+  }
+});
 ```
 
-```ts
-// Option 2: get the populate object and use where you see fit
-const populate = await strapi.plugin("deep-populate").service("populate").get({ documentId: 'xyz', contentType: 'api::page.page' })
-const document = strapi.documents('api::page.page').findOne({ documentId: 'xyz', populate })
-```
-```ts
-// Option 3: use the `findOne` method that wraps around documentService.findOne
-const { findOne } = strapi.plugin("deep-populate").service("populate").documents("api::page.page")
-const document = await findOne({ documentId: 'xyz' })
-```
+### Basic Usage
 
 ```ts
-// Using the wrapped FindOne provides some handy features:
-
-// Allow you to override the populate this way:
-const documentWithCreatedBy = findOne({ documentId: 'xyz', populate: ['createdBy']})
-const documentWithoutSection = findOne({ documentId: 'xyz', populate: { section: false }})
-
-// And if you supply a `*` as populate, it will return a fully populated document (i.e. non-sparse)
-const sparseDocument = findOne({ documentId: 'xyz' }) // sparse, so only attributes are returned that have a value
-const fullDocument = findOne({ documentId: 'xyz', populate: '*' })   // fully populated, so all attributes are returned
+// Get fully populated document
+const document = await strapi.documents("api.page.page").findOne({
+  documentId: 'xyz',
+  populate: '*'
+});
 ```
 
-### populateCreatorFields
+### Advanced Usage
 
-The plugin honors the `populateCreatorFields`<a href="#fn1"><sup>[1]</sup></a> parameter at the content-type level. When set to true, the `createdBy` and `updatedBy` fields will be populated automatically.
+```ts
+// Get populate object for custom usage
+const populate = await strapi.plugin("deep-populate")
+  .service("populate")
+  .get({
+    documentId: 'xyz',
+    contentType: 'api::page.page',
+    omitEmpty: true // optional
+  });
 
-<sup id="fn1">[1]</sup>: https://docs.strapi.io/dev-docs/api/rest/guides/populate-creator-fields
+const document = await strapi.documents('api::page.page').findOne({
+  documentId: 'xyz',
+  populate
+});
+```
 
+### Caching
 
----
+The plugin caches populate objects to improve performance. Cache can be disabled via the `cachePopulate` setting.
 
-## When should you use this?
+### Creator Fields
 
-There are multiple arguments on why Strapi does not populate nested relations itself and requires you to explicitly state the population scheme:
+The plugin automatically populates `createdBy` and `updatedBy` fields when `populateCreatorFields` is enabled in the content-type configuration.
 
-- it's quicker and consumes less resources
-- you don't accidentally expose too much data
-- ... (add your own here, there are probably more)
+## How It Works
 
-However, in some data schemes (see the playground for an example), you don't know beforehand the relations that are going to be nested. This then requires you to implement some form of recursion to get the nested relations. That's where this plugin can be used so you don't have to think about it.
+The plugin recursively:
+1. Traverses the content-type schema
+2. Retrieves documents with one-level deep populate
+3. Resolves all nested relations
+4. Returns a complete populate object
 
-## How does it work
-
-In short: it recursively resolves the content type schema for each attribute and queries the database to see if there is any value set.
-
-A bit longer: You provide it with a documentId and a content type. It then recursively traverses the schema, retrieves the actual document with one-level deep populate and keeps doing this until all relations are resolved. Then it returns the full populate object that you can use to retrieve all relations in one go for that specific document.
-It takes care of some edge cases (e.g. circular relations) and works for all types of relations, most notably the dynamic zone (which has a different format to populate in Strapi).
-
-## Planned features
-
-The following features are planned:
-
-- Cache the populate object for a documentId/content-type combo and its latest changes to prevent having to parse the schema every time
-- Invalidate said cache using db lifecycle hooks
+This process handles all relation types including dynamic zones and circular references.

--- a/playground/__tests__/services/populate/middleware.test.ts
+++ b/playground/__tests__/services/populate/middleware.test.ts
@@ -1,4 +1,4 @@
-import type { Data, Modules } from "@strapi/strapi"
+import type { Core, Data, Modules } from "@strapi/strapi"
 import { setupStrapi, strapi, teardownStrapi } from "../../helpers/strapi"
 
 const mockDate = "2025-01-01T12:00:00.000Z"
@@ -35,6 +35,9 @@ describe("lifecycle", () => {
   const contentType = "api::section.section" as const
   const OriginalDate = Date
 
+  const sections: Record<string, Modules.Documents.AnyDocument> = {}
+  const expected: Record<string, object> = {}
+
   beforeAll(async () => {
     await setupStrapi()
 
@@ -47,6 +50,32 @@ describe("lifecycle", () => {
         return new OriginalDate(mockDate).getTime()
       }
     } as DateConstructor
+
+    // Make sure the relevant objects exist
+    sections.third = await strapi.documents(contentType).create({ data: { name: "level-three" } })
+    sections.second = await strapi.documents(contentType).create({
+      data: { name: "level-two", sections: { connect: [sections.third.documentId] } },
+    })
+    sections.first = await strapi.documents(contentType).create({
+      data: { name: "level-one", sections: { connect: [sections.second.documentId] } },
+    })
+
+    // Re-usable expectations for cleaner tests
+    // non populated
+    expected.thirdNonPopulated = getNonPopulated(sections.third as Data.Entity<typeof contentType>)
+    expected.secondNonPopulated = getNonPopulated(sections.second as Data.Entity<typeof contentType>)
+    expected.firstNonPopulated = getNonPopulated(sections.first as Data.Entity<typeof contentType>)
+
+    // deeply populated
+    expected.thirdDeeplyPopulated = getDeeplyPopulated(sections.third as Data.Entity<typeof contentType>)
+    expected.secondDeeplyPopulated = getDeeplyPopulated({
+      ...sections.second,
+      sections: [expected.thirdDeeplyPopulated],
+    } as Data.Entity<typeof contentType>)
+    expected.firstDeeplyPopulated = getDeeplyPopulated({
+      ...sections.first,
+      sections: [expected.secondDeeplyPopulated],
+    } as Data.Entity<typeof contentType>)
   })
 
   afterAll(async () => {
@@ -55,37 +84,6 @@ describe("lifecycle", () => {
   })
 
   describe("find", () => {
-    const sections: Record<string, Modules.Documents.AnyDocument> = {}
-    const expected: Record<string, object> = {}
-
-    beforeAll(async () => {
-      // Make sure the relevant objects exist
-      sections.third = await strapi.documents(contentType).create({ data: { name: "level-three" } })
-      sections.second = await strapi.documents(contentType).create({
-        data: { name: "level-two", sections: { connect: [sections.third.documentId] } },
-      })
-      sections.first = await strapi.documents(contentType).create({
-        data: { name: "level-one", sections: { connect: [sections.second.documentId] } },
-      })
-
-      // Re-usable expectations for cleaner tests
-      // non populated
-      expected.thirdNonPopulated = getNonPopulated(sections.third as Data.Entity<typeof contentType>)
-      expected.secondNonPopulated = getNonPopulated(sections.second as Data.Entity<typeof contentType>)
-      expected.firstNonPopulated = getNonPopulated(sections.first as Data.Entity<typeof contentType>)
-
-      // deeply populated
-      expected.thirdDeeplyPopulated = getDeeplyPopulated(sections.third as Data.Entity<typeof contentType>)
-      expected.secondDeeplyPopulated = getDeeplyPopulated({
-        ...sections.second,
-        sections: [expected.thirdDeeplyPopulated],
-      } as Data.Entity<typeof contentType>)
-      expected.firstDeeplyPopulated = getDeeplyPopulated({
-        ...sections.first,
-        sections: [expected.secondDeeplyPopulated],
-      } as Data.Entity<typeof contentType>)
-    })
-
     describe("findOne", () => {
       test("should fallback to strapi default when populate is not `*`", async () => {
         const document = await strapi.documents(contentType).findOne({
@@ -134,6 +132,61 @@ describe("lifecycle", () => {
           expected.thirdDeeplyPopulated,
         ])
       })
+    })
+  })
+
+  describe("cache", () => {
+    let cacheService: Core.Service
+    let getCacheSpy: ReturnType<typeof vitest.spyOn>
+    let setCacheSpy: ReturnType<typeof vitest.spyOn>
+
+    beforeAll(() => {
+      cacheService = strapi.service("plugin::deep-populate.cache")
+      getCacheSpy = vitest.spyOn(cacheService, "get")
+      setCacheSpy = vitest.spyOn(cacheService, "set")
+    })
+
+    beforeEach(() => {
+      getCacheSpy.mockReset()
+      setCacheSpy.mockReset()
+    })
+
+    test("create should fill the cache", async () => {
+      // Create new document, which triggers the cache
+      await strapi.documents(contentType).create({ data: { name: "cached" } })
+
+      expect(getCacheSpy).toHaveBeenCalledTimes(1)
+      expect(setCacheSpy).toHaveBeenCalledTimes(1)
+    })
+
+    test("should retrieve the cached result", async () => {
+      const document = await strapi.documents(contentType).findOne({
+        documentId: sections.first.documentId,
+        populate: "*",
+      })
+
+      expect(document).toEqual(expected.firstDeeplyPopulated)
+      expect(getCacheSpy).toHaveBeenCalledTimes(1)
+      expect(setCacheSpy).toHaveBeenCalledTimes(0)
+    })
+
+    test("clear should delete the cached entry", async () => {
+      const params = {
+        contentType: contentType,
+        documentId: sections.first.documentId,
+        locale: null,
+      }
+
+      // Check to see if the cache is populated
+      const cachedResult = await cacheService.get(params)
+      expect(cachedResult).toBeDefined()
+
+      // Clear the cache
+      await strapi.service("plugin::deep-populate.cache").clear(params)
+
+      // Try to get the cache
+      const clearedResult = await cacheService.get(params)
+      expect(clearedResult).toBeNull()
     })
   })
 })

--- a/server/src/config/index.ts
+++ b/server/src/config/index.ts
@@ -1,4 +1,4 @@
 export default {
-  default: ({ env }) => ({ augmentPopulateStar: true }),
+  default: ({ env }) => ({ cachePopulate: true, augmentPopulateStar: true }),
   validator: (config) => {},
 }

--- a/server/src/content-types/cache/index.ts
+++ b/server/src/content-types/cache/index.ts
@@ -1,0 +1,3 @@
+import schema from "./schema"
+
+export default { schema }

--- a/server/src/content-types/cache/schema.ts
+++ b/server/src/content-types/cache/schema.ts
@@ -1,0 +1,39 @@
+export default {
+  kind: "collectionType",
+  collectionName: "caches",
+  info: {
+    singularName: "cache",
+    pluralName: "caches",
+    displayName: "Cache",
+    description: "Holds cached deep populate object",
+  },
+  options: {},
+  pluginOptions: {
+    "content-manager": {
+      visible: false,
+    },
+    "content-type-builder": {
+      visible: false,
+    },
+  },
+  attributes: {
+    hash: {
+      type: "string",
+      configurable: false,
+      required: true,
+    },
+    populate: {
+      type: "json",
+      configurable: false,
+    },
+    dependencies: { type: "json", configurable: false },
+  },
+  // experimental feature:
+  indexes: [
+    {
+      name: "deep-populate_cache_hash_index",
+      columns: ["hash"],
+      type: "unique",
+    },
+  ],
+}

--- a/server/src/content-types/index.ts
+++ b/server/src/content-types/index.ts
@@ -1,0 +1,3 @@
+import cache from "./cache"
+
+export default { cache }

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,9 +1,11 @@
 import config from "./config"
+import contentTypes from "./content-types"
 import register from "./register"
 import services from "./services"
 
 export default {
   config,
+  contentTypes,
   services,
   register,
 }

--- a/server/src/services/cache.ts
+++ b/server/src/services/cache.ts
@@ -1,0 +1,30 @@
+import type { Core, Modules } from "@strapi/strapi"
+
+import type { PopulateParams } from "./populate"
+
+type SetPopulateParams = PopulateParams & Modules.Documents.Params.Pick<PopulateParams["contentType"], "populate">
+
+const getHash = (params: PopulateParams) => {
+  return `${params.contentType}-${params.documentId}-${params.locale}-${params.status}-${params.omitEmpty ? "sparse" : "full"}`
+}
+
+export default ({ strapi }: { strapi: Core.Strapi }) => ({
+  async get(params: PopulateParams) {
+    const entry = await strapi
+      .documents("plugin::deep-populate.cache")
+      .findFirst({ filters: { hash: { $eq: getHash(params) } } })
+    return entry ? entry.populate : null
+  },
+  async set({ populate, ...params }: SetPopulateParams) {
+    await strapi.documents("plugin::deep-populate.cache").create({ data: { hash: getHash(params), populate } })
+  },
+  async clear(params: PopulateParams) {
+    const entry = await strapi
+      .documents("plugin::deep-populate.cache")
+      .findFirst({ filters: { hash: { $eq: getHash(params) } } })
+    if (entry) {
+      return await strapi.documents("plugin::deep-populate.cache").delete({ documentId: entry.documentId })
+    }
+    return null
+  },
+})

--- a/server/src/services/deep-populate/types.d.ts
+++ b/server/src/services/deep-populate/types.d.ts
@@ -7,8 +7,8 @@ type PopulateInternalProps = {
   omitEmpty?: boolean
 }
 type PopulateBaseProps<TContentType extends UID.ContentType, TSchema extends UID.Schema> = PopulateInternalProps & {
-  mainUid: TContentType
-  mainDocumentId: string
+  contentType: TContentType
+  documentId: string
   schema: TSchema
   populate?: Any<TContentType>
   lookup?: string[]

--- a/server/src/services/index.ts
+++ b/server/src/services/index.ts
@@ -1,5 +1,7 @@
+import cache from "./cache"
 import populate from "./populate"
 
 export default {
   populate,
+  cache,
 }

--- a/server/src/services/populate.ts
+++ b/server/src/services/populate.ts
@@ -1,46 +1,28 @@
 import type { Core, Modules, UID } from "@strapi/strapi"
-import { dset } from "dset/merge"
+
+import type config from "../config"
 import populate from "./deep-populate"
 
-const createWrappedFindOne = <const TContentType extends UID.ContentType = UID.ContentType>(
-  contentType: TContentType,
-  findOne: Modules.Documents.ServiceInstance<TContentType>["findOne"],
-) => {
-  const wrappedFindOne: typeof findOne = (async (params) => {
-    const { documentId, populate: originalPopulate } = params
-    const deepPopulate = await populate({
-      mainUid: contentType,
-      mainDocumentId: documentId,
-      schema: contentType,
-      omitEmpty: originalPopulate !== "*",
-    })
-
-    // Try to merge the original populate with the deepPopulate
-    if (originalPopulate && originalPopulate !== "*") {
-      strapi.log.warn(`passed "populate" will be merged with deepPopulate, which could result in unexpected behavior.`)
-      if (typeof originalPopulate === "object")
-        Object.keys(originalPopulate).map((k) => dset(deepPopulate, k, originalPopulate[k]))
-      if (Array.isArray(originalPopulate)) originalPopulate.map((k) => dset(deepPopulate, k, true))
-    }
-
-    return await findOne({ ...params, populate: deepPopulate })
-  }) as unknown as typeof findOne
-
-  return wrappedFindOne
+export type PopulateParams<TContentType extends UID.ContentType = UID.ContentType> = Modules.Documents.Params.Pick<
+  TContentType,
+  "locale:string" | "status"
+> & {
+  contentType: TContentType
+  documentId: string
+  omitEmpty?: boolean
 }
 
 export default ({ strapi }: { strapi: Core.Strapi }) => ({
-  async get({
-    contentType,
-    documentId,
-    omitEmpty = false,
-  }: { contentType: UID.ContentType; documentId: string; omitEmpty?: boolean }) {
-    return populate({ mainUid: contentType, mainDocumentId: documentId, schema: contentType, omitEmpty })
-  },
-  documents(contentType: UID.ContentType) {
-    const documents = strapi.documents(contentType)
-    const { findOne, ...wrapped } = strapi.documents(contentType)
+  async get(params: PopulateParams) {
+    const { cachePopulate } = strapi.config.get<ReturnType<(typeof config)["default"]>>("plugin::deep-populate")
 
-    return { ...wrapped, findOne: createWrappedFindOne(contentType, findOne) } as typeof documents
+    if (!cachePopulate) return await populate(params)
+
+    const cachedEntry = await strapi.service("plugin::deep-populate.cache").get(params)
+    if (cachedEntry) return cachedEntry
+
+    const resolved = await populate(params)
+    await strapi.service("plugin::deep-populate.cache").set({ ...params, populate: resolved })
+    return resolved
   },
 })

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "@strapi/typescript-utils/tsconfigs/server",
   "compilerOptions": {
     "rootDir": "../",
-    "noEmit": true
+    "noEmit": true,
+    "esModuleInterop": true
   },
   "include": ["./src"]
 }


### PR DESCRIPTION
Added caching layer to improve performance of deep populate queries
Implemented cache invalidation strategy for content updates 
Updated documentation to reflect new caching behavior

Closes: https://github.com/Four-Lights-NL/strapi-plugin-deep-populate/issues/15