### PR TITLE
Hotfix: remove incorrect experimental index

### DIFF
--- a/server/src/content-types/cache/schema.ts
+++ b/server/src/content-types/cache/schema.ts
@@ -40,10 +40,5 @@ export default {
       columns: ["hash"],
       type: "unique",
     },
-    {
-      name: "deep-populate_cache_dependencies_index",
-      columns: ["dependencies"],
-      type: "fulltext",
-    },
   ],
 }


### PR DESCRIPTION
I'll try to add it back using a migration, which allows more control over how to add the index.