### PR TITLE
Add optional `blacklist` and `whitelist` configuration 

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ It does not impose a limit on the level of nesting and can cache the populate ob
 - Handles circular references and edge cases
 - Includes caching for improved performance
 - Honors `populateCreatorFields` setting
+- Supports whitelisting or blacklisting specific relations or components during population
 
 ## Installation
 
@@ -71,6 +72,35 @@ The plugin caches populate objects to improve performance. Cache can be disabled
 ### Creator Fields
 
 The plugin automatically populates `createdBy` and `updatedBy` fields when `populateCreatorFields` is enabled in the content-type configuration.
+
+### Whitelisting or Blacklisting
+
+Sometimes you may want to restrict the nested population of certain relations or components. For example if you have a `Page` contentType where a deeply nested `Link` component has a relation to another `Page`.
+In those situations you can use the whitelist or blacklist configuration:
+
+```ts
+// config/plugins.js
+module.exports = ({ env }) => ({
+  'deep-populate': {
+    enabled: true,
+    config: {
+      useCache: true,
+      replaceWildcard: true,
+      
+      contentTypes: {
+        'api::page.page': {
+          /* whitelist: { relations: [], components[] } */
+          blacklist: {
+            relations: ['api::page.page']  // prevent resolving nested pages when populating a page
+            // alternatively we could have blacklisted the link component in this case
+            // components: ['shared.link']
+          }
+        }
+      }
+    }
+  }
+});
+```
 
 ## How It Works
 

--- a/playground/__tests__/services/populate/config.test.ts
+++ b/playground/__tests__/services/populate/config.test.ts
@@ -1,0 +1,111 @@
+import type { Data, UID } from "@strapi/strapi"
+import { setupDocuments } from "../../helpers/setupDocuments"
+import { setupStrapi, strapi, teardownStrapi } from "../../helpers/strapi"
+import type { UnwrapPromise } from "../../helpers/unwrapPromise"
+
+describe("config", () => {
+  let context: UnwrapPromise<ReturnType<typeof setupDocuments>> & {
+    sectionWithLink: Data.Entity
+    pageWithLink: Data.Entity
+    shallowPopulatedTargetPage: Data.Entity
+  }
+  const contentType = "api::page.page"
+
+  let originalConfigGet: typeof strapi.config.get
+  let configSpy: ReturnType<typeof vitest.spyOn>
+
+  const configContentTypes: Record<UID.ContentType, unknown> = {}
+
+  beforeAll(async () => {
+    await setupStrapi()
+
+    originalConfigGet = strapi.config.get
+    configSpy = vitest.spyOn(strapi.config, "get")
+    configSpy.mockImplementation((key) => {
+      const config = { ...originalConfigGet.call(strapi.config, key), useCache: false }
+      if (key === "plugin::deep-populate")
+        return {
+          ...(config as object),
+          contentTypes: configContentTypes,
+        }
+      return config
+    })
+
+    context = (await setupDocuments()) as unknown as typeof context
+
+    context.sectionWithLink = await strapi.documents("api::section.section").create({
+      data: {
+        blocks: [
+          {
+            __component: "shared.link",
+            label: "to main page",
+            page: context.page.documentId,
+          },
+        ],
+      },
+      populate: ["localizations", "target", "singleCoolComponent", "sections", "coolitems", "blocks"],
+    })
+
+    context.pageWithLink = await strapi.documents(contentType).create({
+      data: {
+        title: "page with link",
+        sections: [context.sectionWithLink.documentId],
+      },
+      populate: ["image", "localizations", "members"],
+    })
+
+    context.shallowPopulatedTargetPage = await strapi
+      .documents(contentType)
+      .findOne({ documentId: context.page.documentId })
+  })
+
+  afterAll(async () => {
+    await teardownStrapi()
+  })
+
+  beforeEach(async () => {
+    configSpy.mockClear()
+  })
+
+  describe("blacklist", () => {
+    test("should not populate blacklisted relations", async () => {
+      configContentTypes[contentType] = {
+        blacklist: { relations: [contentType] },
+      }
+
+      const document = await strapi
+        .documents(contentType)
+        .findOne({ documentId: context.pageWithLink.documentId, populate: "*" })
+
+      expect(document).toEqual({
+        ...context.pageWithLink,
+        sections: [
+          {
+            ...context.sectionWithLink,
+            blocks: [{ ...context.sectionWithLink.blocks[0], page: context.shallowPopulatedTargetPage }],
+          },
+        ],
+      })
+    })
+
+    test("should not populate blacklisted components", async () => {
+      configContentTypes[contentType] = {
+        blacklist: { components: ["shared.link"] },
+      }
+
+      const document = await strapi
+        .documents(contentType)
+        .findOne({ documentId: context.pageWithLink.documentId, populate: "*" })
+
+      expect(document).toEqual({
+        ...context.pageWithLink,
+        sections: [
+          {
+            ...context.sectionWithLink,
+            blocks: [{ ...context.sectionWithLink.blocks[0], page: context.shallowPopulatedTargetPage }],
+          },
+        ],
+      })
+    })
+  })
+})

--- a/playground/src/api/section/content-types/section/schema.json
+++ b/playground/src/api/section/content-types/section/schema.json
@@ -42,7 +42,7 @@
     },
     "blocks": {
       "type": "dynamiczone",
-      "components": ["cms.special", "cms.cool-component", "cms.slider"]
+      "components": ["cms.special", "cms.cool-component", "cms.slider", "shared.link"]
     }
   }
 }

--- a/server/src/config/index.ts
+++ b/server/src/config/index.ts
@@ -1,4 +1,67 @@
+import type { UID } from "@strapi/strapi"
+import isEmpty from "lodash/isEmpty"
+import isObject from "lodash/isObject"
+
+export type ContentTypeConfigWhitelist = {
+  relations?: UID.ContentType[]
+  components?: UID.Component[]
+}
+
+export type ContentTypeConfigBlacklist = {
+  relations?: UID.ContentType[]
+  components?: UID.Component[]
+}
+
+type ContentTypeConfig = {
+  whitelist?: ContentTypeConfigWhitelist
+  blacklist?: ContentTypeConfigBlacklist
+}
+
+export type Config = {
+  useCache: boolean
+  replaceWildcard: boolean
+  contentTypes: Record<UID.ContentType, ContentTypeConfig>
+}
+
 export default {
-  default: ({ env }) => ({ useCache: true, replaceWildcard: true }),
-  validator: (config) => {},
+  default: ({ env }) => ({ useCache: true, replaceWildcard: true, contentTypes: {} }),
+  validator: (config: Config) => {
+    if (!isObject(config.contentTypes)) {
+      throw new Error("plugin::deep-populate config.contentTypes must be an object")
+    }
+    if (!isEmpty(config.contentTypes)) {
+      for (const [uid, contentTypeConfig] of Object.entries(config.contentTypes)) {
+        if (!isObject(contentTypeConfig)) {
+          throw new Error(`plugin::deep-populate config.contentTypes.${uid} must be an object`)
+        }
+        if (!contentTypeConfig.whitelist && !contentTypeConfig.blacklist) {
+          throw new Error(
+            `plugin::deep-populate config.contentTypes.${uid} must have either a "whitelist" or "blacklist".`,
+          )
+        }
+        if (contentTypeConfig.whitelist && !isObject(contentTypeConfig.whitelist)) {
+          throw new Error(`plugin::deep-populate config.contentTypes.${uid}.whitelist must be an object`)
+        }
+        if (contentTypeConfig.blacklist && !isObject(contentTypeConfig.blacklist)) {
+          throw new Error(`plugin::deep-populate config.contentTypes.${uid}.blacklist must be an object`)
+        }
+        if (contentTypeConfig.whitelist) {
+          if (contentTypeConfig.whitelist.relations && !Array.isArray(contentTypeConfig.whitelist.relations)) {
+            throw new Error(`plugin::deep-populate config.contentTypes.${uid}.whitelist.relations must be an array`)
+          }
+          if (contentTypeConfig.whitelist.components && !Array.isArray(contentTypeConfig.whitelist.components)) {
+            throw new Error(`plugin::deep-populate config.contentTypes.${uid}.whitelist.components must be an array`)
+          }
+        }
+        if (contentTypeConfig.blacklist) {
+          if (contentTypeConfig.blacklist.relations && !Array.isArray(contentTypeConfig.blacklist.relations)) {
+            throw new Error(`plugin::deep-populate config.contentTypes.${uid}.blacklist.relations must be an array`)
+          }
+          if (contentTypeConfig.blacklist.components && !Array.isArray(contentTypeConfig.blacklist.components)) {
+            throw new Error(`plugin::deep-populate config.contentTypes.${uid}.blacklist.components must be an array`)
+          }
+        }
+      }
+    }
+  },
 }

--- a/server/src/services/deep-populate/types.d.ts
+++ b/server/src/services/deep-populate/types.d.ts
@@ -1,10 +1,13 @@
 import type { Data, Modules, UID } from "@strapi/strapi"
+import type { ContentTypeConfigBlacklist, ContentTypeConfigWhitelist } from "../../config"
 
 type PopulateType = Record<string, "*" | { populate: unknown } | { on: Record<`${string}.${string}`, unknown> }> | true
 
 type PopulateInternalProps = {
   resolvedRelations: Map<string, PopulateType>
   omitEmpty?: boolean
+  __blacklist?: ContentTypeConfigBlacklist
+  __whitelist?: ContentTypeConfigWhitelist
 }
 type PopulateBaseProps<TContentType extends UID.ContentType, TSchema extends UID.Schema> = PopulateInternalProps &
   Modules.Documents.Params.Pick<TContentType, "locale:string" | "status"> & {

--- a/server/src/services/populate.ts
+++ b/server/src/services/populate.ts
@@ -1,6 +1,6 @@
 import type { Core, Modules, UID } from "@strapi/strapi"
 
-import type config from "../config"
+import type { Config } from "../config"
 import populate from "./deep-populate"
 
 export type PopulateParams<TContentType extends UID.ContentType = UID.ContentType> = Modules.Documents.Params.Pick<
@@ -14,7 +14,7 @@ export type PopulateParams<TContentType extends UID.ContentType = UID.ContentTyp
 
 export default ({ strapi }: { strapi: Core.Strapi }) => ({
   async get(params: PopulateParams) {
-    const { useCache } = strapi.config.get<ReturnType<(typeof config)["default"]>>("plugin::deep-populate")
+    const { useCache } = strapi.config.get("plugin::deep-populate") as Config
 
     if (!useCache) return (await populate(params)).populate
 


### PR DESCRIPTION
To allow control over where `deep-populate` should not go.