### PR TITLE
Do not populate localizations unless specifically asked to

### DIFF
--- a/server/src/services/cache.ts
+++ b/server/src/services/cache.ts
@@ -6,7 +6,7 @@ type SetPopulateParams = PopulateParams &
   Modules.Documents.Params.Pick<PopulateParams["contentType"], "populate"> & { dependencies: string[] }
 
 const getHash = (params: PopulateParams) => {
-  return `${params.contentType}-${params.documentId}-${params.locale}-${params.status}-${params.omitEmpty ? "sparse" : "full"}`
+  return `${params.contentType}-${params.documentId}-${params.locale}-${params.status}-${params.omitEmpty ? "sparse" : "full"}-${params.localizations ? "all" : "single"}`
 }
 
 export default ({ strapi }: { strapi: Core.Strapi }) => ({

--- a/server/src/services/deep-populate/index.ts
+++ b/server/src/services/deep-populate/index.ts
@@ -74,11 +74,7 @@ async function _populateRelation<TContentType extends UID.ContentType>({
   contentType,
   relation,
   resolvedRelations,
-  omitEmpty,
-  locale,
-  status,
-  __deny,
-  __allow,
+  ...params
 }: PopulateRelationProps<TContentType>) {
   const isSingleRelation = !Array.isArray(relation)
   const relations = isSingleRelation ? [relation] : relation
@@ -93,11 +89,7 @@ async function _populateRelation<TContentType extends UID.ContentType>({
       documentId: relation.documentId,
       schema: contentType,
       resolvedRelations,
-      omitEmpty,
-      locale,
-      status,
-      __deny,
-      __allow,
+      ...params,
     })
 
     resolvedRelations.set(relation.documentId, relationPopulate)
@@ -206,7 +198,12 @@ async function _populate<TContentType extends UID.ContentType, TSchema extends U
     const value = _resolveValue({ document, attrName, lookup })
 
     if (!hasValue(value)) {
-      if (!omitEmpty) newPopulate[attrName] = true
+      if (omitEmpty !== true) newPopulate[attrName] = true
+      continue
+    }
+
+    if (params.localizations !== true && attrName === "localizations" && hasValue(value)) {
+      newPopulate[attrName] = true
       continue
     }
 
@@ -269,6 +266,7 @@ async function _populate<TContentType extends UID.ContentType, TSchema extends U
         omitEmpty,
         locale: params.locale,
         status: params.status,
+        localizations: params.localizations,
         __deny,
         __allow,
       })

--- a/server/src/services/deep-populate/types.d.ts
+++ b/server/src/services/deep-populate/types.d.ts
@@ -6,6 +6,7 @@ type PopulateType = Record<string, "*" | { populate: unknown } | { on: Record<`$
 type PopulateInternalProps = {
   resolvedRelations: Map<string, PopulateType>
   omitEmpty?: boolean
+  localizations?: boolean
   __deny?: ContentTypeConfigDeny
   __allow?: ContentTypeConfigAllow
 }

--- a/server/src/services/populate.ts
+++ b/server/src/services/populate.ts
@@ -10,6 +10,7 @@ export type PopulateParams<TContentType extends UID.ContentType = UID.ContentTyp
   contentType: TContentType
   documentId: string
   omitEmpty?: boolean
+  localizations?: boolean
 }
 
 export default ({ strapi }: { strapi: Core.Strapi }) => ({


### PR DESCRIPTION
You can still populate them by calling the `populate` service directly with `localizations: true` 

e.g.
```ts
await strapi.plugin('deep-populate').service('populate').get({ /* other params */, localizations: true }
```