### PR TITLE
 Fix inconsistent return type of populate `get` 

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ const document = await strapi.documents("api.page.page").findOne({
 
 ```ts
 // Get populate object for custom usage
-const { populate } = await strapi.plugin("deep-populate")
+const populate = await strapi.plugin("deep-populate")
   .service("populate")
   .get({
     documentId: 'xyz',
@@ -88,6 +88,7 @@ module.exports = ({ env }) => ({
       replaceWildcard: true,
       
       contentTypes: {
+        // '*' would apply to all content types
         'api::page.page': {
           deny: {
             relations: ['api::page.page']  // prevent resolving nested pages when populating a page

--- a/playground/__tests__/services/populate/get.test.ts
+++ b/playground/__tests__/services/populate/get.test.ts
@@ -34,17 +34,17 @@ describe("get", () => {
     })
 
     test("no relation", async () => {
-      const { populate } = await service.get({ contentType, documentId: sections[0].documentId, omitEmpty: true })
+      const populate = await service.get({ contentType, documentId: sections[0].documentId, omitEmpty: true })
       expect(populate).toStrictEqual({})
     })
 
     test("relation one level deep", async () => {
-      const { populate } = await service.get({ contentType, documentId: sections[1].documentId, omitEmpty: true })
+      const populate = await service.get({ contentType, documentId: sections[1].documentId, omitEmpty: true })
       expect(populate).toStrictEqual({ sections: true })
     })
 
     test("relation two levels deep", async () => {
-      const { populate } = await service.get({ contentType, documentId: sections[2].documentId, omitEmpty: true })
+      const populate = await service.get({ contentType, documentId: sections[2].documentId, omitEmpty: true })
       expect(populate).toStrictEqual({
         sections: { populate: { sections: true } },
       })
@@ -68,7 +68,7 @@ describe("get", () => {
           Modules.Documents.Params.Data.Input<typeof contentType>
         >,
       })
-      const { populate } = await service.get({ contentType, documentId: sectionA.documentId, omitEmpty: true })
+      const populate = await service.get({ contentType, documentId: sectionA.documentId, omitEmpty: true })
       expect(populate).toStrictEqual({
         sections: { populate: { sections: true } },
       })
@@ -104,7 +104,7 @@ describe("get", () => {
         },
       })
 
-      const { populate } = await service.get({ contentType, documentId, omitEmpty: true })
+      const populate = await service.get({ contentType, documentId, omitEmpty: true })
       expect(populate).toStrictEqual({
         coolitems: {
           populate: {
@@ -121,7 +121,7 @@ describe("get", () => {
           singleCoolComponent: components.single,
         },
       })
-      const { populate } = await service.get({ contentType, documentId, omitEmpty: true })
+      const populate = await service.get({ contentType, documentId, omitEmpty: true })
       expect(populate).toStrictEqual({
         singleCoolComponent: true,
       })
@@ -134,7 +134,7 @@ describe("get", () => {
           singleCoolComponent: components.singleWithNestedSingle,
         },
       })
-      const { populate } = await service.get({ contentType, documentId, omitEmpty: true })
+      const populate = await service.get({ contentType, documentId, omitEmpty: true })
       expect(populate).toStrictEqual({
         singleCoolComponent: {
           populate: { specialSingle: true },
@@ -149,7 +149,7 @@ describe("get", () => {
           singleCoolComponent: components.singleWithNestedRepeatable,
         },
       })
-      const { populate } = await service.get({ contentType, documentId, omitEmpty: true })
+      const populate = await service.get({ contentType, documentId, omitEmpty: true })
       expect(populate).toStrictEqual({
         singleCoolComponent: {
           populate: { specialRepeatable: true },
@@ -181,7 +181,7 @@ describe("get", () => {
           ],
         },
       })
-      const { populate } = await service.get({ contentType, documentId, omitEmpty: true })
+      const populate = await service.get({ contentType, documentId, omitEmpty: true })
       expect(populate).toStrictEqual({
         blocks: {
           on: {
@@ -213,7 +213,7 @@ describe("get", () => {
         },
       })
 
-      const { populate } = await service.get({ contentType, documentId, omitEmpty: true })
+      const populate = await service.get({ contentType, documentId, omitEmpty: true })
       expect(populate).toStrictEqual({
         image: true,
       })
@@ -237,7 +237,7 @@ describe("get", () => {
           ],
         },
       })
-      const { populate } = await service.get({ contentType: "api::section.section", documentId, omitEmpty: true })
+      const populate = await service.get({ contentType: "api::section.section", documentId, omitEmpty: true })
       expect(populate).toStrictEqual({
         blocks: {
           on: {

--- a/server/src/services/populate.ts
+++ b/server/src/services/populate.ts
@@ -24,6 +24,6 @@ export default ({ strapi }: { strapi: Core.Strapi }) => ({
 
     const resolved = await populate(params)
     await strapi.service("plugin::deep-populate.cache").set({ ...params, ...resolved })
-    return resolved
+    return resolved.populate
   },
 })


### PR DESCRIPTION
It should always only return the `populate` object. This resulted in inconsistent errors on initial cache creation.