### PR TITLE
Fix/plugin hangs when caching simple content types

### DIFF
--- a/playground/config/env/test/plugins.ts
+++ b/playground/config/env/test/plugins.ts
@@ -6,4 +6,5 @@ export default ({ env }) => ({
       jwtSecret: env("JWT_SECRET", randomBytes(16).toString("base64")),
     },
   },
+  "deep-populate": { enabled: true },
 })

--- a/playground/config/plugins.ts
+++ b/playground/config/plugins.ts
@@ -1,3 +1,3 @@
 export default ({ env }) => ({
-  "deep-populate": {},
+  "deep-populate": { enabled: true },
 })

--- a/playground/package-lock.json
+++ b/playground/package-lock.json
@@ -28,12 +28,10 @@
       "extraneous": true
     },
     ".yalc/@fourlights/strapi-plugin-deep-populate": {
-      "version": "1.1.1",
+      "version": "1.5.0",
       "license": "MIT",
       "dependencies": {
-        "dlv": "^1.1.3",
-        "dset": "^3.1.4",
-        "klona": "^2.0.6"
+        "lodash": "^4.17.21"
       },
       "peerDependencies": {
         "@strapi/sdk-plugin": "^5",
@@ -8755,12 +8753,6 @@
         "libmime": "^2.0.3"
       }
     },
-    "node_modules/dlv": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
-      "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
-      "license": "MIT"
-    },
     "node_modules/dnd-core": {
       "version": "16.0.1",
       "resolved": "https://registry.npmjs.org/dnd-core/-/dnd-core-16.0.1.tgz",
@@ -8883,15 +8875,6 @@
       },
       "funding": {
         "url": "https://dotenvx.com"
-      }
-    },
-    "node_modules/dset": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/dset/-/dset-3.1.4.tgz",
-      "integrity": "sha512-2QF/g9/zTaPDc3BjNcVTGoBbXBgYfMTTceLaYcFJ/W9kggFUkhxD/hMEeuLKbugyef9SqAx8cpgwlIP/jinUTA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/dunder-proto": {
@@ -12039,15 +12022,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/klona": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/klona/-/klona-2.0.6.tgz",
-      "integrity": "sha512-dhG34DXATL5hSxJbIexCft8FChFXtmskoZYnoPWjXQuebWYCNkVeV3KkGegCK9CP1oswI/vQibS2GY7Em/sJJA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 8"
       }
     },
     "node_modules/knex": {

--- a/server/src/services/cache.ts
+++ b/server/src/services/cache.ts
@@ -1,4 +1,5 @@
 import type { Core, Modules } from "@strapi/strapi"
+import isEmpty from "lodash/isEmpty"
 
 import type { PopulateParams } from "./populate"
 
@@ -14,7 +15,7 @@ export default ({ strapi }: { strapi: Core.Strapi }) => ({
     const entry = await strapi
       .documents("plugin::deep-populate.cache")
       .findFirst({ filters: { hash: { $eq: getHash(params) } } })
-    return entry ? entry.populate : null
+    return entry && !isEmpty(entry.populate) ? entry.populate : null
   },
   async set({ populate, dependencies, ...params }: SetPopulateParams) {
     const documentService = strapi.documents("plugin::deep-populate.cache")


### PR DESCRIPTION
A simple content-type will have an empty resolved populate object which should be passed as a `null` when resolving, otherwise a non-breaking loop will occur.

This is a prime example on why we need to add end-to-end tests that actually call the playground API, as this bug was part of the documents hook that is hard to trigger from unit or integration tests.

Fixes https://github.com/Four-Lights-NL/strapi-plugin-deep-populate/issues/52