### PR TITLE
test: add tests for bustCache parameter

### DIFF
--- a/playground/__tests__/services/populate/api.test.ts
+++ b/playground/__tests__/services/populate/api.test.ts
@@ -84,4 +84,110 @@ describe("api", () => {
       expect(cachedSimple.body.data).toEqual(expected)
     })
   })
+
+  describe("bustCache parameter", () => {
+    beforeEach(async () => {
+      const cachedEntries = await strapi.documents("plugin::deep-populate.cache").findMany({})
+      for (const entry of cachedEntries) {
+        await strapi.documents("plugin::deep-populate.cache").delete({ documentId: entry.documentId })
+      }
+    })
+
+    it("should use cached version when bustCache is not provided", async () => {
+      expect(await strapi.documents("plugin::deep-populate.cache").count({ status: "draft" })).toBe(0)
+
+      // First request - should populate cache
+      const firstResponse = await supertest(strapi.server.httpServer)
+        .get(`/api/pages/${context.page.documentId}`)
+        .set("Authorization", `Bearer ${jwt}`)
+        .query({ populate: "*", status: "draft" })
+        .expect(200)
+
+      // check directly with strapi if the cache was filled
+      expect(await strapi.documents("plugin::deep-populate.cache").count({ status: "draft" })).toBe(1)
+      const cacheOne = await strapi.documents("plugin::deep-populate.cache").findFirst({})
+
+      // Second request - should use cache
+      const secondResponse = await supertest(strapi.server.httpServer)
+        .get(`/api/pages/${context.page.documentId}`)
+        .set("Authorization", `Bearer ${jwt}`)
+        .query({ populate: "*", status: "draft" })
+        .expect(200)
+
+      expect(firstResponse.body.data).toEqual(secondResponse.body.data)
+
+      expect(await strapi.documents("plugin::deep-populate.cache").count({ status: "draft" })).toBe(1)
+      const cacheTwo = await strapi.documents("plugin::deep-populate.cache").findFirst({})
+      expect(cacheOne.params).toEqual(cacheTwo.params)
+    })
+
+    it("should refresh cache when bustCache=true", async () => {
+      expect(await strapi.documents("plugin::deep-populate.cache").count({ status: "draft" })).toBe(0)
+
+      // First request - populate cache
+      await supertest(strapi.server.httpServer)
+        .get(`/api/pages/${context.page.documentId}`)
+        .set("Authorization", `Bearer ${jwt}`)
+        .query({ populate: "*", status: "draft" })
+        .expect(200)
+
+      // check directly with strapi if the cache was filled
+      expect(await strapi.documents("plugin::deep-populate.cache").count({ status: "draft" })).toBe(1)
+      const cacheOne = await strapi.documents("plugin::deep-populate.cache").findFirst({})
+      console.log(cacheOne.dependencies)
+
+      // update the cached entry slightly to see if the return changes
+      await strapi.documents("plugin::deep-populate.cache").update({
+        documentId: cacheOne.documentId,
+        data: { dependencies: "test" } as Partial<Modules.Documents.Params.Data.Input<"plugin::deep-populate.cache">>,
+      })
+      const cacheTwo = await strapi.documents("plugin::deep-populate.cache").findFirst({})
+      expect(cacheOne.dependencies).not.toEqual(cacheTwo.dependencies)
+
+      // Request with bustCache=true
+      await supertest(strapi.server.httpServer)
+        .get(`/api/pages/${context.page.documentId}`)
+        .set("Authorization", `Bearer ${jwt}`)
+        .query({ populate: "*", status: "draft", bustCache: true })
+        .expect(200)
+
+      expect(await strapi.documents("plugin::deep-populate.cache").count({ status: "draft" })).toBe(1)
+      const cacheThree = await strapi.documents("plugin::deep-populate.cache").findFirst({})
+      expect(cacheOne.dependencies).toEqual(cacheThree.dependencies)
+    })
+
+    it("should bust cache for findMany operations", async () => {
+      expect(await strapi.documents("plugin::deep-populate.cache").count({ status: "draft" })).toBe(0)
+
+      // First request - populate cache
+      await supertest(strapi.server.httpServer)
+        .get("/api/pages")
+        .set("Authorization", `Bearer ${jwt}`)
+        .query({ populate: "*", status: "draft" })
+        .expect(200)
+
+      // check directly with strapi if the cache was filled
+      expect(await strapi.documents("plugin::deep-populate.cache").count({ status: "draft" })).toBe(1)
+      const cacheOne = await strapi.documents("plugin::deep-populate.cache").findFirst({})
+
+      // update the cached entry slightly to see if the return changes
+      await strapi.documents("plugin::deep-populate.cache").update({
+        documentId: cacheOne.documentId,
+        data: { dependencies: "test" } as Partial<Modules.Documents.Params.Data.Input<"plugin::deep-populate.cache">>,
+      })
+      const cacheTwo = await strapi.documents("plugin::deep-populate.cache").findFirst({})
+      expect(cacheOne.dependencies).not.toEqual(cacheTwo.dependencies)
+
+      // Request with bustCache=true - should get fresh data for all pages
+      await supertest(strapi.server.httpServer)
+        .get("/api/pages")
+        .set("Authorization", `Bearer ${jwt}`)
+        .query({ populate: "*", status: "draft", bustCache: true })
+        .expect(200)
+
+      expect(await strapi.documents("plugin::deep-populate.cache").count({ status: "draft" })).toBe(1)
+      const cacheThree = await strapi.documents("plugin::deep-populate.cache").findFirst({})
+      expect(cacheOne.dependencies).toEqual(cacheThree.dependencies)
+    })
+  })
 })


### PR DESCRIPTION
Add test coverage for bustCache parameter functionality across different scenarios:
- Default caching behavior when parameter is omitted
- Cache refresh with bustCache=true for findOne operations
- Cache busting for findMany operations

Related #95 