### PR TITLE
fix(deep-populate): flatten to-many relations on repeatable components

### DIFF
--- a/playground/__tests__/helpers/setupDocuments.ts
+++ b/playground/__tests__/helpers/setupDocuments.ts
@@ -42,15 +42,19 @@ export const setupDocuments = async (linkToPageId?: string) => {
     populate: {
       target: true,
       localizations: { populate: "*" },
-      singleCoolComponent: { populate: { specialRepeatable: { populate: { users: true } }, specialSingle: true } },
-      coolitems: { populate: { specialRepeatable: { populate: { users: true } }, specialSingle: true } },
+      singleCoolComponent: {
+        populate: { specialRepeatable: { populate: { users: true, linkedSections: true } }, specialSingle: true },
+      },
+      coolitems: {
+        populate: { specialRepeatable: { populate: { users: true, linkedSections: true } }, specialSingle: true },
+      },
       sections: true,
       blocks: {
         on: {
           "cms.cool-component": {
             populate: {
-              specialSingle: { populate: { users: true } },
-              specialRepeatable: { populate: { users: true } },
+              specialSingle: { populate: { users: true, linkedSections: true } },
+              specialRepeatable: { populate: { users: true, linkedSections: true } },
             },
           },
           "cms.special": { populate: "*" },
@@ -104,13 +108,15 @@ export const setupDocuments = async (linkToPageId?: string) => {
       target: true,
       singleCoolComponent: true,
       localizations: { populate: "*" },
-      coolitems: { populate: { specialSingle: true, specialRepeatable: { populate: { users: true } } } },
+      coolitems: {
+        populate: { specialSingle: true, specialRepeatable: { populate: { users: true, linkedSections: true } } },
+      },
       blocks: {
         on: {
           "cms.cool-component": {
             populate: {
-              specialSingle: { populate: { users: true } },
-              specialRepeatable: { populate: { users: true } },
+              specialSingle: { populate: { users: true, linkedSections: true } },
+              specialRepeatable: { populate: { users: true, linkedSections: true } },
             },
           },
           "cms.special": { populate: "*" },

--- a/playground/__tests__/services/populate/get.test.ts
+++ b/playground/__tests__/services/populate/get.test.ts
@@ -156,6 +156,34 @@ describe("get", () => {
       })
     })
 
+    test("repeatable component with a to-many relation, multiple instances", async () => {
+      const linkedSectionOne = await strapi.documents(contentType).create({ data: { name: "linked-section-one" } })
+      const linkedSectionTwo = await strapi.documents(contentType).create({ data: { name: "linked-section-two" } })
+
+      const { documentId } = await strapi.documents(contentType).create({
+        data: {
+          name: "repeatable-component-with-to-many-relation",
+          singleCoolComponent: {
+            title: "single",
+            isCool: true,
+            text: "single component with a repeatable sub-component holding a to-many relation",
+            specialRepeatable: [
+              { isSpecial: false, name: "first", linkedSections: { connect: [linkedSectionOne.documentId] } },
+              { isSpecial: true, name: "second", linkedSections: { connect: [linkedSectionTwo.documentId] } },
+            ],
+          },
+        },
+      })
+
+      // Regression test: when a to-many relation (oneToMany/manyToMany) lives on a component that
+      // is itself repeatable, and there are 2+ instances of that component, `_resolveValue` used to
+      // produce an array of arrays instead of a flat array, which crashed `_populateRelation`.
+      const populate = await service.get({ contentType, documentId, omitEmpty: true })
+      expect(populate.singleCoolComponent).toStrictEqual({
+        populate: { specialRepeatable: { populate: { linkedSections: true } } },
+      })
+    })
+
     test("dynamiczone", async () => {
       const { documentId } = await strapi.documents(contentType).create({
         data: {

--- a/playground/src/components/cms/special.json
+++ b/playground/src/components/cms/special.json
@@ -17,6 +17,11 @@
       "type": "relation",
       "relation": "oneToOne",
       "target": "plugin::users-permissions.user"
+    },
+    "linkedSections": {
+      "type": "relation",
+      "relation": "oneToMany",
+      "target": "api::section.section"
     }
   }
 }

--- a/server/src/services/deep-populate/index.ts
+++ b/server/src/services/deep-populate/index.ts
@@ -105,7 +105,10 @@ async function _populateRelation<TContentType extends UID.ContentType>({
   ...params
 }: PopulateRelationProps<TContentType>) {
   const isSingleRelation = !Array.isArray(relation)
-  const relations = isSingleRelation ? [relation] : relation
+  // When a to-many relation is defined on a component that is itself repeatable, `_resolveValue`
+  // maps the relation across each component instance, producing an array of arrays (one per
+  // instance) instead of a flat array of related entities. Flatten it here to normalize both shapes.
+  const relations = (isSingleRelation ? [relation] : relation).flat() as Data.Entity<TContentType>[]
 
   // Forward pass to prevent circular references
   const nonResolvedRelations = relations.filter(


### PR DESCRIPTION
When a to-many relation (oneToMany/manyToMany) is defined on a component that is itself repeatable, and the parent has 2+ instances of that component, _resolveValue mapped the relation across each instance, producing an array of arrays instead of a flat array. _populateRelation then destructured documentId off nested arrays, pushing undefined into resolvedRelations and crashing populate with
'Cannot read properties of undefined (reading startsWith)'.

Flatten the relations array in _populateRelation to normalize both the single-instance and repeated-instance shapes.