### PR TITLE
fix(ci): handle fork PRs in autofix workflow

### DIFF
--- a/.github/workflows/autofix.yaml
+++ b/.github/workflows/autofix.yaml
@@ -13,9 +13,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
         with:
-          ref: ${{ github.head_ref }}
+          ref: refs/pull/${{ github.event.pull_request.number }}/merge
           fetch-depth: 1
-          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Prepare
         uses: ./.github/actions/prepare
@@ -24,19 +23,21 @@ jobs:
         run: npm run ci
 
       - name: Config Git
+        if: github.event.pull_request.head.repo.full_name == github.repository
         run: |
           git config user.name "${GITHUB_ACTOR}"
           git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
 
       - name: Commit changes
+        if: github.event.pull_request.head.repo.full_name == github.repository
         uses: actions/github-script@v9
         with:
-          github-token: ${{secrets.GITHUB_TOKEN}}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const git = require('simple-git')();
             const changes = await git.diffSummary();
             if (changes.files.length > 0) {
               await git.add('./*');
               await git.commit('chore: apply automated fixes');
-              await git.push();
+              await git.push('origin', 'HEAD:${{ github.event.pull_request.head.ref }}');
             }


### PR DESCRIPTION
Fork PRs have an empty github.head_ref, causing checkout to fail when it tries to fetch a non-existent branch. Use the pull request merge ref instead, which works for both fork and same-repo PRs. Also gate the auto-commit step on same-repo PRs since GITHUB_TOKEN cannot push to a contributor's fork.