### PR TITLE
fix: detect MySQL duplicate entry errors when Knex wraps the error ob…

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.3.5/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.0/schema.json",
   "vcs": {
     "enabled": false,
     "clientKind": "git",
@@ -29,17 +29,35 @@
           "level": "on",
           "options": {
             "groups": [
-              { "source": [":BUN:", ":NODE:"], "type": true },
+              {
+                "source": [":BUN:", ":NODE:"],
+                "type": true
+              },
               ":BLANK_LINE:",
-              { "source": [":BUN:", ":NODE:"], "type": false },
+              {
+                "source": [":BUN:", ":NODE:"],
+                "type": false
+              },
               ":BLANK_LINE:",
-              { "source": [":PACKAGE:", ":BLANK_LINE:"], "type": true },
+              {
+                "source": [":PACKAGE:"],
+                "type": true
+              },
               ":BLANK_LINE:",
-              { "source": [":PACKAGE:", ":BLANK_LINE:"], "type": false },
+              {
+                "source": [":PACKAGE:"],
+                "type": false
+              },
               ":BLANK_LINE:",
-              { "source": [":ALIAS:", ":PATH:"], "type": true },
+              {
+                "source": [":ALIAS:", ":PATH:"],
+                "type": true
+              },
               ":BLANK_LINE:",
-              { "source": [":ALIAS:", ":PATH:"], "type": false }
+              {
+                "source": [":ALIAS:", ":PATH:"],
+                "type": false
+              }
             ]
           }
         },
@@ -52,7 +70,7 @@
   "linter": {
     "enabled": true,
     "rules": {
-      "recommended": true,
+      "preset": "recommended",
       "style": {
         "noParameterAssign": "error",
         "useAsConstAssertion": "error",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "lodash": "^4.17.21"
       },
       "devDependencies": {
-        "@biomejs/biome": "^2.3.6",
+        "@biomejs/biome": "^2.5.1",
         "@strapi/database": "^5.31.0",
         "@strapi/sdk-plugin": "^5.3.2",
         "@strapi/strapi": "^5.31.0",
@@ -838,9 +838,9 @@
       }
     },
     "node_modules/@biomejs/biome": {
-      "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.3.6.tgz",
-      "integrity": "sha512-oqUhWyU6tae0MFsr/7iLe++QWRg+6jtUhlx9/0GmCWDYFFrK366sBLamNM7D9Y+c7YSynUFKr8lpEp1r6Sk7eA==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.5.1.tgz",
+      "integrity": "sha512-IXWLCxKmae+rI7LOHS1B3EbVisQ6GRAWbhN9msa6KjNCyFWrvKZWR4oUdinaNssrV852OrSHuSPa95h1GPJc7Q==",
       "dev": true,
       "license": "MIT OR Apache-2.0",
       "bin": {
@@ -854,20 +854,20 @@
         "url": "https://opencollective.com/biome"
       },
       "optionalDependencies": {
-        "@biomejs/cli-darwin-arm64": "2.3.6",
-        "@biomejs/cli-darwin-x64": "2.3.6",
-        "@biomejs/cli-linux-arm64": "2.3.6",
-        "@biomejs/cli-linux-arm64-musl": "2.3.6",
-        "@biomejs/cli-linux-x64": "2.3.6",
-        "@biomejs/cli-linux-x64-musl": "2.3.6",
-        "@biomejs/cli-win32-arm64": "2.3.6",
-        "@biomejs/cli-win32-x64": "2.3.6"
+        "@biomejs/cli-darwin-arm64": "2.5.1",
+        "@biomejs/cli-darwin-x64": "2.5.1",
+        "@biomejs/cli-linux-arm64": "2.5.1",
+        "@biomejs/cli-linux-arm64-musl": "2.5.1",
+        "@biomejs/cli-linux-x64": "2.5.1",
+        "@biomejs/cli-linux-x64-musl": "2.5.1",
+        "@biomejs/cli-win32-arm64": "2.5.1",
+        "@biomejs/cli-win32-x64": "2.5.1"
       }
     },
     "node_modules/@biomejs/cli-darwin-arm64": {
-      "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.3.6.tgz",
-      "integrity": "sha512-P4JWE5d8UayBxYe197QJwyW4ZHp0B+zvRIGCusOm1WbxmlhpAQA1zEqQuunHgSIzvyEEp4TVxiKGXNFZPg7r9Q==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.5.1.tgz",
+      "integrity": "sha512-npqDzvqv7vFaWRiNN1Te71siRgPaqS9MpqgYCdP/CrUbkJ7ApezaeaKjueKHRN/JH/6lRjJQAHi8acQDCAz22w==",
       "cpu": [
         "arm64"
       ],
@@ -882,9 +882,9 @@
       }
     },
     "node_modules/@biomejs/cli-darwin-x64": {
-      "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.3.6.tgz",
-      "integrity": "sha512-I4rTebj+F/L9K93IU7yTFs8nQ6EhaCOivxduRha4w4WEZK80yoZ8OAdR1F33m4yJ/NfUuTUbP/Wjs+vKjlCoWA==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.5.1.tgz",
+      "integrity": "sha512-RgwTqPAM8g2tn1j+b5oRjF/DbSBX8a4gwojtuG9XuhfK7GgomvZ9+T+tqjXiVbjLEeGJOoL6VEk8mvRTVeSybw==",
       "cpu": [
         "x64"
       ],
@@ -899,13 +899,16 @@
       }
     },
     "node_modules/@biomejs/cli-linux-arm64": {
-      "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.3.6.tgz",
-      "integrity": "sha512-JjYy83eVBnvuINZiqyFO7xx72v8Srh4hsgaacSBCjC22DwM6+ZvnX1/fj8/SBiLuUOfZ8YhU2pfq2Dzakeyg1A==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.5.1.tgz",
+      "integrity": "sha512-yhV35CzZh38VyMvTEXi3JTjxZBs++oCKK9KG8vB6VI5+uvQvZNR3BFWEKKzuOmx9DJJj7sQpZ4LQJcmbGTs3+Q==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -916,13 +919,16 @@
       }
     },
     "node_modules/@biomejs/cli-linux-arm64-musl": {
-      "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.3.6.tgz",
-      "integrity": "sha512-oK1NpIXIixbJ/4Tcx40cwiieqah6rRUtMGOHDeK2ToT7yUFVEvXUGRKqH0O4hqZ9tW8TcXNZKfgRH6xrsjVtGg==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.5.1.tgz",
+      "integrity": "sha512-WMcvMLgByyTqVxGlq918NBBYliq9FRR9GAQVETHb+VjGVqXCZFfHlZHC1FX4ibuYY/Hg6TJE3rHU0xVrdJXNRw==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -933,13 +939,16 @@
       }
     },
     "node_modules/@biomejs/cli-linux-x64": {
-      "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.3.6.tgz",
-      "integrity": "sha512-ZjPXzy5yN9wusIoX+8Zp4p6cL8r0NzJCXg/4r1KLVveIPXd2jKVlqZ6ZyzEq385WwU3OX5KOwQYLQsOc788waQ==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.5.1.tgz",
+      "integrity": "sha512-J/7uHSX7NfoYDI7HijAkd8lnQIOrRb2W7j3X+tw4R+N5ExvXGsyXFiGdQcfcxfOmNQmZVSQOCDk757fwpzqQcg==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -950,13 +959,16 @@
       }
     },
     "node_modules/@biomejs/cli-linux-x64-musl": {
-      "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.3.6.tgz",
-      "integrity": "sha512-QvxB8GHQeaO4FCtwJpJjCgJkbHBbWxRHUxQlod+xeaYE6gtJdSkYkuxdKAQUZEOIsec+PeaDAhW9xjzYbwmOFA==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.5.1.tgz",
+      "integrity": "sha512-ANTowtlLmPYm5yeMckWY8Xzb9Ix+JJP3tgHR/n6xRj1VWyIzzWtfRfih9hv9VmClwadpBvZduISZIbBsIlYG3A==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -967,9 +979,9 @@
       }
     },
     "node_modules/@biomejs/cli-win32-arm64": {
-      "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.3.6.tgz",
-      "integrity": "sha512-YM7hLHpwjdt8R7+O2zS1Vo2cKgqEeptiXB1tWW1rgjN5LlpZovBVKtg7zfwfRrFx3i08aNZThYpTcowpTlczug==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.5.1.tgz",
+      "integrity": "sha512-zgXnKNgWPC4iPF7Y1lR3STUeCUuZRpD6IiOrC7TZTlh0Lx6FiVUT05myuMQHQ9D+1cc7uyMldi4forE6lp0ivQ==",
       "cpu": [
         "arm64"
       ],
@@ -984,9 +996,9 @@
       }
     },
     "node_modules/@biomejs/cli-win32-x64": {
-      "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.3.6.tgz",
-      "integrity": "sha512-psgNEYgMAobY5h+QHRBVR9xvg2KocFuBKm6axZWB/aD12NWhQjiVFQUjV6wMXhlH4iT0Q9c3yK5JFRiDC/rzHA==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.5.1.tgz",
+      "integrity": "sha512-6uxpR9hvaglANkZemeSiN/FhYgkGasrEGn267eXIWvjrjJ2LhDlk251IhjVJq6MXzkV2/bcXwLwSroLyPtqRZg==",
       "cpu": [
         "x64"
       ],

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "lodash": "^4.17.21"
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.3.6",
+    "@biomejs/biome": "^2.5.1",
     "@strapi/database": "^5.31.0",
     "@strapi/sdk-plugin": "^5.3.2",
     "@strapi/strapi": "^5.31.0",

--- a/server/src/services/cache.ts
+++ b/server/src/services/cache.ts
@@ -43,20 +43,25 @@ export default ({ strapi }: { strapi: Core.Strapi }) => ({
   async set({ populate, dependencies, ...params }: SetPopulateParams) {
     const documentService = strapi.documents("plugin::deep-populate.cache")
     const hash = getHash(params)
+    const data = { populate, dependencies: dependencies.join(",") } as Partial<
+      Modules.Documents.Params.Data.Input<"plugin::deep-populate.cache">
+    >
 
     try {
-      return await documentService.create({ data: { hash, params, populate, dependencies: dependencies.join(",") } })
+      const existing = await documentService.findFirst({ filters: { hash: { $eq: hash } } })
+
+      if (existing) {
+        return await documentService.update({ documentId: existing.documentId, data })
+      }
+
+      return await documentService.create({ data: { hash, params, ...data } })
     } catch (error: unknown) {
+      // Guard against the rare race condition where two concurrent requests both
+      // see no entry and both attempt to create — one will hit a duplicate key error.
       if (isUniqueConstraintError(error)) {
         const entry = await documentService.findFirst({ filters: { hash: { $eq: hash } } })
-
         if (entry) {
-          return await documentService.update({
-            documentId: entry.documentId,
-            data: { populate, dependencies: dependencies.join(",") } as Partial<
-              Modules.Documents.Params.Data.Input<"plugin::deep-populate.cache">
-            >,
-          })
+          return await documentService.update({ documentId: entry.documentId, data })
         }
       }
 

--- a/server/src/utils/isUniqueConstraintError.ts
+++ b/server/src/utils/isUniqueConstraintError.ts
@@ -15,15 +15,20 @@ const UniqueConstraintErrorCodes = {
 } as const
 
 export const isUniqueConstraintError = (error: unknown): boolean => {
-  const err = error as { code?: string; errno?: number; number?: number }
+  const err = error as { code?: string; errno?: number; number?: number; cause?: unknown; originalError?: unknown; parent?: unknown }
+  const cause = (err.cause || err.originalError || err.parent || {}) as { code?: string; errno?: number; number?: number }
+
+  const errno = err.errno ?? cause.errno
+  const code = err.code ?? cause.code
+  const number = err.number ?? cause.number
 
   return (
-    Object.keys(UniqueConstraintErrorCodes).includes(err.code) ||
-    err.code === UniqueConstraintErrorCodes.POSTGRES_UNIQUE_VIOLATION ||
-    err.errno === UniqueConstraintErrorCodes.MYSQL_DUPLICATE_ENTRY ||
-    err.errno === UniqueConstraintErrorCodes.SQLITE_CONSTRAINT ||
-    err.errno === UniqueConstraintErrorCodes.SQLITE_CONSTRAINT_UNIQUE ||
-    err.number === UniqueConstraintErrorCodes.SQLSERVER_DUPLICATE_KEY ||
-    err.number === UniqueConstraintErrorCodes.SQLSERVER_UNIQUE_KEY_VIOLATION
+    Object.keys(UniqueConstraintErrorCodes).includes(code) ||
+    code === UniqueConstraintErrorCodes.POSTGRES_UNIQUE_VIOLATION ||
+    errno === UniqueConstraintErrorCodes.MYSQL_DUPLICATE_ENTRY ||
+    errno === UniqueConstraintErrorCodes.SQLITE_CONSTRAINT ||
+    errno === UniqueConstraintErrorCodes.SQLITE_CONSTRAINT_UNIQUE ||
+    number === UniqueConstraintErrorCodes.SQLSERVER_DUPLICATE_KEY ||
+    number === UniqueConstraintErrorCodes.SQLSERVER_UNIQUE_KEY_VIOLATION
   )
 }

--- a/server/src/utils/isUniqueConstraintError.ts
+++ b/server/src/utils/isUniqueConstraintError.ts
@@ -15,8 +15,19 @@ const UniqueConstraintErrorCodes = {
 } as const
 
 export const isUniqueConstraintError = (error: unknown): boolean => {
-  const err = error as { code?: string; errno?: number; number?: number; cause?: unknown; originalError?: unknown; parent?: unknown }
-  const cause = (err.cause || err.originalError || err.parent || {}) as { code?: string; errno?: number; number?: number }
+  const err = error as {
+    code?: string
+    errno?: number
+    number?: number
+    cause?: unknown
+    originalError?: unknown
+    parent?: unknown
+  }
+  const cause = (err.cause || err.originalError || err.parent || {}) as {
+    code?: string
+    errno?: number
+    number?: number
+  }
 
   const errno = err.errno ?? cause.errno
   const code = err.code ?? cause.code


### PR DESCRIPTION
Problem

cache.set() always attempts an INSERT first, causing a duplicate key error whenever the same document is populated more than once (e.g. saving a draft, concurrent requests). The error was supposed to be caught and handled as an upsert, but isUniqueConstraintError was also broken on MySQL — Knex wraps the error object so errno: 1062 sits at err.cause.errno rather than err.errno, causing the check to return false and fall through to log.error("Failed to save cached entry").

Fix

Two changes:

cache.set() — check for an existing entry first and UPDATE it directly. INSERT only when no entry exists. The isUniqueConstraintError catch is kept as a safety net for the rare true race condition (two concurrent requests both see no entry and both attempt to create).

isUniqueConstraintError — unwrap err.cause, err.originalError, and err.parent before checking error codes, so MySQL duplicate key errors are correctly detected regardless of how Knex wraps them.