### PR TITLE
chore: sync package.json to already-published v1.16.0-rc.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fourlights/strapi-plugin-deep-populate",
-  "version": "1.15.0",
+  "version": "1.16.0-rc.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@fourlights/strapi-plugin-deep-populate",
-      "version": "1.15.0",
+      "version": "1.16.0-rc.0",
       "license": "MIT",
       "dependencies": {
         "lodash": "^4.17.21"

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.15.0",
+  "version": "1.16.0-rc.0",
   "keywords": [
     "strapi",
     "strapi-plugin",


### PR DESCRIPTION
## Why

The Publish workflow run for v1.16.0-rc.0 succeeded through `npm publish` (package is live on npm with the `rc` dist-tag), but the final `git push` to `main` failed because `main` is a protected branch and rejected a direct push from `github.token`:

```
remote: error: GH006: Protected branch update failed for refs/heads/main.
remote: - Changes must be made through a pull request.
```

`release-it` rolled back the local commit/tag after the push failure, but the npm publish had already happened and cannot be undone. This leaves `package.json` on `main` at `1.15.0` while npm's `rc` tag points at `1.16.0-rc.0`.

## What

Manually applies the same version bump `release-it` would have committed (`npm version 1.16.0-rc.0 --no-git-tag-version`), so git and npm are back in sync. No code changes.

## Follow-up

Root cause (release automation can't push to protected `main`) will be fixed by giving the release workflow a scoped bypass for branch protection, tracked separately.