### PR TITLE
ci(release): use GitHub App token to bypass main branch protection

### DIFF
--- a/.github/workflows/prerelease.yaml
+++ b/.github/workflows/prerelease.yaml
@@ -13,6 +13,13 @@ on:
         required: false
         type: string
         default: 'beta'
+    secrets:
+      RELEASE_APP_ID:
+        description: 'App ID of the GitHub App allowed to bypass branch protection on main for releases'
+        required: true
+      RELEASE_APP_PRIVATE_KEY:
+        description: 'Private key of the GitHub App allowed to bypass branch protection on main for releases'
+        required: true
 permissions:
   id-token: write
   contents: write
@@ -22,11 +29,18 @@ jobs:
     name: Publish
     runs-on: ubuntu-latest
     steps:
+      - name: Generate release token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
       - name: Checkout
         uses: actions/checkout@v7
         with:
           fetch-depth: 0
-          token: ${{ github.token }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Prepare
         uses: ./.github/actions/prepare
@@ -41,10 +55,10 @@ jobs:
 
       - name: Config Git
         run: |
-          git config user.name "${GITHUB_ACTOR}"
-          git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+          git config user.name "${{ steps.app-token.outputs.app-slug }}[bot]"
+          git config user.email "${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com"
 
       - name: Run release
         run: npm run release -- ${{ github.event.inputs.bump_type }} --ci --preRelease=${{ github.event.inputs.release_type }}
         env:
-          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -37,6 +37,9 @@ jobs:
     uses: ./.github/workflows/release.yaml
     with:
       bump_type: ${{ github.event.inputs.bump_type }}
+    secrets:
+      RELEASE_APP_ID: ${{ secrets.RELEASE_APP_ID }}
+      RELEASE_APP_PRIVATE_KEY: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
     permissions:
       id-token: write
       contents: write
@@ -48,6 +51,9 @@ jobs:
     with:
       bump_type: ${{ github.event.inputs.bump_type }}
       release_type: ${{ github.event.inputs.release_type }}
+    secrets:
+      RELEASE_APP_ID: ${{ secrets.RELEASE_APP_ID }}
+      RELEASE_APP_PRIVATE_KEY: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
     permissions:
       id-token: write
       contents: write

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,6 +8,13 @@ on:
         required: false
         default: 'patch'
         type: string
+    secrets:
+      RELEASE_APP_ID:
+        description: 'App ID of the GitHub App allowed to bypass branch protection on main for releases'
+        required: true
+      RELEASE_APP_PRIVATE_KEY:
+        description: 'Private key of the GitHub App allowed to bypass branch protection on main for releases'
+        required: true
 permissions:
   id-token: write
   contents: write
@@ -17,11 +24,18 @@ jobs:
     name: Publish
     runs-on: ubuntu-latest
     steps:
+      - name: Generate release token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
       - name: Checkout
         uses: actions/checkout@v7
         with:
           fetch-depth: 1
-          token: ${{ github.token }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Prepare
         uses: ./.github/actions/prepare
@@ -36,10 +50,10 @@ jobs:
 
       - name: Config Git
         run: |
-          git config user.name "${GITHUB_ACTOR}"
-          git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+          git config user.name "${{ steps.app-token.outputs.app-slug }}[bot]"
+          git config user.email "${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com"
 
       - name: Run release
         run: npm run release -- --ci -i ${{ github.event.inputs.bump_type }}
         env:
-          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
## Why

The `Publish` workflow's `git push` to `main` fails when releasing, because `main` requires PRs and the built-in `github.token` has no way to bypass that:

```
remote: error: GH006: Protected branch update failed for refs/heads/main.
remote: - Changes must be made through a pull request.
```

This bit us on the v1.16.0-rc.0 release: `npm publish` succeeded (can't be undone) but the version-bump commit/tag never landed on `main`, requiring a manual follow-up (#150).

A `PAT_TOKEN` secret was tried for this before (see 0416bb1 / d0bf839) but reverted, presumably because no bypass was configured for it either, so it would have hit the same wall.

## What

- `prerelease.yaml`/`release.yaml` now mint a short-lived installation token via `actions/create-github-app-token@v3`, using two new required secrets: `RELEASE_APP_ID` and `RELEASE_APP_PRIVATE_KEY`.
- That token is used for checkout, git commit identity, and as `GITHUB_TOKEN` for `release-it` (which uses it both to `git push` and to create the GitHub Release).
- `publish.yaml` forwards the two secrets into the reusable workflows.

## Required manual follow-up (not doable via API)

1. Create a GitHub App scoped to this repo only, with `Contents: Read & write` + `Metadata: Read-only` permissions.
2. Install it on `Four-Lights-NL/strapi-plugin-deep-populate`.
3. Add `RELEASE_APP_ID` and `RELEASE_APP_PRIVATE_KEY` as repo secrets.
4. Convert `main`'s branch protection to a Ruleset (classic protection has no per-actor bypass) and add the app to the ruleset's bypass list, restricted to pull requests only, so it can push release commits without needing a PR while all other rules stay enforced.

Until that setup exists, running `Publish` will fail immediately and clearly on the new "Generate release token" step (missing secret), instead of repeating the previous partial-failure (successful `npm publish`, failed git push).

## Cleanup

There's also a leftover, unused `PAT_TOKEN` repo secret from the earlier attempt that should be deleted once this is verified working.