### PR TITLE
fix(ci): auto-force prerelease bump when main is already on a prerelease

### DIFF
--- a/.github/workflows/prerelease.yaml
+++ b/.github/workflows/prerelease.yaml
@@ -58,7 +58,39 @@ jobs:
           git config user.name "${{ steps.app-token.outputs.app-slug }}[bot]"
           git config user.email "${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com"
 
+      - name: Determine effective bump type
+        id: bump
+        env:
+          REQUESTED_BUMP: ${{ inputs.bump_type }}
+          RELEASE_TYPE: ${{ inputs.release_type }}
+        run: |
+          node -e "
+            const semver = require('semver');
+            const current = require('./package.json').version;
+            const pre = semver.prerelease(current);
+            const requestedBump = process.env.REQUESTED_BUMP;
+            const releaseType = process.env.RELEASE_TYPE;
+            let effective;
+            if (pre) {
+              // main is already sitting on a prerelease (e.g. 1.16.0-rc.0). A plain
+              // patch/minor/major bump would incorrectly jump the major.minor.patch
+              // (e.g. minor => 1.17.0-rc.0) instead of continuing the existing chain.
+              // 'prerelease' is the only correct increment here: it advances the
+              // counter within the same channel, or restarts at .0 when switching
+              // prerelease channels (e.g. beta -> rc) - never touches major.minor.patch.
+              effective = 'prerelease';
+              console.log('::notice::main is already on prerelease ' + current + '; forcing increment=prerelease (ignoring bump_type=\"' + requestedBump + '\") to avoid an unintended major.minor.patch bump.');
+            } else {
+              if (!requestedBump) {
+                console.error('bump_type is required to start a new ' + releaseType + ' series from a non-prerelease version (' + current + ').');
+                process.exit(1);
+              }
+              effective = requestedBump;
+            }
+            require('fs').appendFileSync(process.env.GITHUB_OUTPUT, 'increment=' + effective + '\n');
+          "
+
       - name: Run release
-        run: npm run release -- ${{ github.event.inputs.bump_type }} --ci --preRelease=${{ github.event.inputs.release_type }}
+        run: npm run release -- ${{ steps.bump.outputs.increment }} --ci --preRelease=${{ inputs.release_type }}
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -54,6 +54,6 @@ jobs:
           git config user.email "${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com"
 
       - name: Run release
-        run: npm run release -- --ci -i ${{ github.event.inputs.bump_type }}
+        run: npm run release -- --ci -i ${{ inputs.bump_type }}
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
## Why

Dispatching \`Publish\` with \`bump_type=minor, release_type=rc\` while \`main\`'s \`package.json\` was already at \`1.16.0-rc.0\` produced \`1.17.0-rc.0\` on npm instead of the intended \`1.16.0-rc.1\`. This is correct \`release-it\`/\`semver\` behavior (\`minor\` on an existing prerelease does a \`preminor\` bump), but it's not what an operator dispatching another rc for the *same* pending minor wants — the workflow silently trusted whatever \`bump_type\` was clicked without ever checking the current state of \`main\`.

The npm package (\`1.17.0-rc.0\`) was manually unpublished from the CLI to recover; this PR prevents the underlying mistake from being possible again.

## What

- \`prerelease.yaml\`: added a "Determine effective bump type" step that reads \`package.json\`'s current version.
  - If it's already a prerelease (e.g. \`1.16.0-rc.0\`), the effective increment is forced to \`prerelease\` and the dispatched \`bump_type\` is ignored/logged as a notice. \`semver.inc('1.16.0-rc.0', 'prerelease', 'rc')\` → \`1.16.0-rc.1\`; switching prerelease channel (e.g. \`beta\` → \`rc\`) correctly resets to \`.0\` without touching major/minor/patch.
  - If it's not a prerelease (starting a fresh series), \`bump_type\` is now required and the job fails fast with a clear message instead of silently falling back to \`release-it\`'s own \`patch\` default.
- \`release.yaml\`: fixed the \`Run release\` step referencing the stale \`github.event.inputs.bump_type\` (should be the reusable workflow's own \`inputs.bump_type\`; only worked before by coincidence since both inputs share the same name).

## Also fixed out-of-band (already applied, not part of this diff)

The \`main\` ruleset's bypass actor for the release GitHub App had \`bypass_mode: "pull_request"\`, which — despite the name — does **not** allow bypassing the "require PR" rule for direct pushes; it only allows the actor to bypass rules while acting within a PR. Changed to \`bypass_mode: "always"\`, which is what actually permits \`release-it\`'s direct \`git push\` to \`main\`. Verified via the API that this persisted.