### PR TITLE
fix: lazy cache invalidation

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,8 @@ Settings are applied in the following priority order (highest to lowest):
 
 The plugin caches populate objects to improve performance. Cache can be disabled
 via the `useCache` setting.  Cache entires are persisted in the database and can
-become stale after content-type updates. You can use the `cacheOptions > clearCacheOnStartup` to force cache purging on server start.
+become stale after content-type updates. You can use the `cacheOptions >
+clearCacheOnStartup` to force cache purging on server start.
 
 #### Cache Configuration
 
@@ -164,6 +165,7 @@ module.exports = ({ env }) => ({
       useCache: true, // Enable caching (default: true)
       cacheOptions: {
         clearCacheOnStartup: false, // Clear cache on server startup (default: false)
+        warmOnWrite: false, // Re-warm cache synchronously after writes; NOTE: can be slow (default: false)
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fourlights/strapi-plugin-deep-populate",
-  "version": "1.16.0",
+  "version": "1.17.0-beta.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@fourlights/strapi-plugin-deep-populate",
-      "version": "1.16.0",
+      "version": "1.17.0-beta.0",
       "license": "MIT",
       "dependencies": {
         "lodash": "^4.17.21"

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.16.0",
+  "version": "1.17.0-beta.0",
   "keywords": [
     "strapi",
     "strapi-plugin",

--- a/playground/__tests__/services/populate/middleware.test.ts
+++ b/playground/__tests__/services/populate/middleware.test.ts
@@ -289,7 +289,7 @@ describe("lifecycle", () => {
     })
   })
 
-  describe("cache with warmOnWrite)", () => {
+  describe("cache with warmOnWrite", () => {
     let cacheService: Core.Service
     let getCacheSpy: ReturnType<typeof vitest.spyOn>
     let setCacheSpy: ReturnType<typeof vitest.spyOn>

--- a/playground/__tests__/services/populate/middleware.test.ts
+++ b/playground/__tests__/services/populate/middleware.test.ts
@@ -136,7 +136,7 @@ describe("lifecycle", () => {
     })
   })
 
-  describe("cache", () => {
+  describe("cache with no warmOnWrite", () => {
     let cacheService: Core.Service
     let getCacheSpy: ReturnType<typeof vitest.spyOn>
     let setCacheSpy: ReturnType<typeof vitest.spyOn>
@@ -152,10 +152,19 @@ describe("lifecycle", () => {
       setCacheSpy.mockReset()
     })
 
-    test("create should fill the cache", async () => {
-      // Create new document, which triggers the cache
-      await strapi.documents(contentType).create({ data: { name: "cached" } })
+    test("create should not warm the cache in lazy mode", async () => {
+      const created = await strapi.documents(contentType).create({ data: { name: "cached" } })
 
+      expect(getCacheSpy).toHaveBeenCalledTimes(0)
+      expect(setCacheSpy).toHaveBeenCalledTimes(0)
+
+      // Next read should populate the cache via the cache-miss path
+      const document = await strapi.documents(contentType).findOne({
+        documentId: created.documentId,
+        populate: "*",
+      })
+
+      expect(document).toBeDefined()
       expect(getCacheSpy).toHaveBeenCalledTimes(1)
       expect(setCacheSpy).toHaveBeenCalledTimes(1)
     })
@@ -190,22 +199,24 @@ describe("lifecycle", () => {
       expect(clearedResult).toBeNull()
     })
 
-    test("should delete cached entry for deleted dependants", async () => {
+    test("should invalidate cached entry for updated dependants", async () => {
       const clearCacheSpy = vitest.spyOn(cacheService, "clear")
       const refreshDependentsCacheSpy = vitest.spyOn(cacheService, "refreshDependents")
 
+      // Create nested + parent and populate their caches via reads
       const nestedSection = await strapi.documents(contentType).create({
         data: { name: "nestedSection" },
       })
-
-      const _parentSection = await strapi.documents(contentType).create({
+      const parentSection = await strapi.documents(contentType).create({
         data: { name: "parentSection", sections: [nestedSection.documentId] },
       })
 
-      expect(setCacheSpy).toHaveBeenCalledTimes(2)
+      // Populate cache for both via read path
+      await strapi.documents(contentType).findOne({ documentId: nestedSection.documentId, populate: "*" })
+      await strapi.documents(contentType).findOne({ documentId: parentSection.documentId, populate: "*" })
+
       setCacheSpy.mockReset()
 
-      // Update the nestedSection, which will clear the cache for nestedSection and refresh it for parentSection
       await strapi.documents(contentType).update({
         documentId: nestedSection.documentId,
         locale: nestedSection.locale,
@@ -215,10 +226,40 @@ describe("lifecycle", () => {
 
       expect(clearCacheSpy).toHaveBeenCalledTimes(1)
       expect(refreshDependentsCacheSpy).toHaveBeenCalledTimes(1)
-      expect(setCacheSpy).toHaveBeenCalledTimes(2)
+      expect(setCacheSpy).toHaveBeenCalledTimes(0)
 
       clearCacheSpy.mockClear()
       refreshDependentsCacheSpy.mockClear()
+    })
+
+    test("should return fresh data after dependent invalidation", async () => {
+      // Create nested + parent and populate their caches via reads
+      const nestedSection = await strapi.documents(contentType).create({
+        data: { name: "staleCheck" },
+      })
+      const parentSection = await strapi.documents(contentType).create({
+        data: { name: "staleCheckParent", sections: [nestedSection.documentId] },
+      })
+
+      // Populate cache for the parent via read
+      const before = await strapi.documents(contentType).findOne({
+        documentId: parentSection.documentId,
+        populate: "*",
+      })
+      expect(before.sections[0].name).toBe("staleCheck")
+
+      // Update the nested document
+      await strapi.documents(contentType).update({
+        documentId: nestedSection.documentId,
+        data: { name: "staleCheckUpdated" } as Partial<Modules.Documents.Params.Data.Input<typeof contentType>>,
+      })
+
+      // The parent's cache entry should have been invalidated; next read returns fresh data
+      const after = await strapi.documents(contentType).findOne({
+        documentId: parentSection.documentId,
+        populate: "*",
+      })
+      expect(after.sections[0].name).toBe("staleCheckUpdated")
     })
 
     test("should update cache when bustCache is true", async () => {
@@ -230,17 +271,99 @@ describe("lifecycle", () => {
         data: { name: "parentSection", sections: [nestedSection.documentId] },
       })
 
-      expect(setCacheSpy).toHaveBeenCalledTimes(2)
+      // Populate cache for parent via read
+      await strapi.documents(contentType).findOne({ documentId: parentSection.documentId, populate: "*" })
+      expect(setCacheSpy).toHaveBeenCalledTimes(1)
       setCacheSpy.mockReset()
 
+      // Cached, so no set
       await strapi.documents(contentType).findOne({ documentId: parentSection.documentId, populate: "*" })
       expect(setCacheSpy).toHaveBeenCalledTimes(0)
 
+      // bustCache forces re-computation
       await strapi
         .documents(contentType)
         .findOne({ documentId: parentSection.documentId, populate: "*", bustCache: true })
 
       expect(setCacheSpy).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe("cache with warmOnWrite)", () => {
+    let cacheService: Core.Service
+    let getCacheSpy: ReturnType<typeof vitest.spyOn>
+    let setCacheSpy: ReturnType<typeof vitest.spyOn>
+    let originalConfigGet: typeof strapi.config.get
+    let configSpy: ReturnType<typeof vitest.spyOn>
+
+    beforeAll(() => {
+      cacheService = strapi.service("plugin::deep-populate.cache")
+      getCacheSpy = vitest.spyOn(cacheService, "get")
+      setCacheSpy = vitest.spyOn(cacheService, "set")
+
+      originalConfigGet = strapi.config.get
+      configSpy = vitest.spyOn(strapi.config, "get")
+      configSpy.mockImplementation((key) => {
+        const config = originalConfigGet.call(strapi.config, key)
+        if (key === "plugin::deep-populate") {
+          return {
+            ...(config as object),
+            useCache: true,
+            cacheOptions: { warmOnWrite: true },
+          }
+        }
+        return config
+      })
+    })
+
+    afterAll(() => {
+      configSpy.mockRestore()
+    })
+
+    beforeEach(() => {
+      getCacheSpy.mockReset()
+      setCacheSpy.mockReset()
+    })
+
+    test("create should warm the cache", async () => {
+      await strapi.documents(contentType).create({ data: { name: "eagerCached" } })
+
+      expect(getCacheSpy).toHaveBeenCalledTimes(1)
+      expect(setCacheSpy).toHaveBeenCalledTimes(1)
+    })
+
+    test("should re-warm cache for updated dependants", async () => {
+      const clearCacheSpy = vitest.spyOn(cacheService, "clear")
+      const refreshDependentsCacheSpy = vitest.spyOn(cacheService, "refreshDependents")
+
+      const nestedSection = await strapi.documents(contentType).create({
+        data: { name: "eagerNested" },
+      })
+      const _parentSection = await strapi.documents(contentType).create({
+        data: { name: "eagerParent", sections: [nestedSection.documentId] },
+      })
+
+      // Both creates warm the cache
+      expect(setCacheSpy).toHaveBeenCalledTimes(2)
+      setCacheSpy.mockReset()
+      clearCacheSpy.mockReset()
+      refreshDependentsCacheSpy.mockReset()
+
+      // Update nested
+      await strapi.documents(contentType).update({
+        documentId: nestedSection.documentId,
+        locale: nestedSection.locale,
+        status: nestedSection.status,
+        data: { name: "eagerNestedUpdated" } as Partial<Modules.Documents.Params.Data.Input<typeof contentType>>,
+      })
+
+      expect(clearCacheSpy).toHaveBeenCalledTimes(1)
+      expect(refreshDependentsCacheSpy).toHaveBeenCalledTimes(1)
+      // Should have rewarmed: 1 for the updated doc + 1 for the dependent parent
+      expect(setCacheSpy).toHaveBeenCalledTimes(2)
+
+      clearCacheSpy.mockClear()
+      refreshDependentsCacheSpy.mockClear()
     })
   })
 })

--- a/server/src/config/index.ts
+++ b/server/src/config/index.ts
@@ -22,6 +22,7 @@ export type ContentTypeConfig = {
 
 export type CacheOptions = {
   clearCacheOnStartup?: boolean
+  warmOnWrite?: boolean
 }
 
 export type Config = {

--- a/server/src/register.ts
+++ b/server/src/register.ts
@@ -92,7 +92,8 @@ export default async ({ strapi }) => {
   })
 
   strapi.documents.use(async (context, next) => {
-    const { useCache, replaceWildcard } = strapi.config.get("plugin::deep-populate")
+    const { useCache, replaceWildcard, cacheOptions } = strapi.config.get("plugin::deep-populate")
+    const warmOnWrite = cacheOptions?.warmOnWrite === true
 
     if (
       // do nothing if not configured
@@ -132,12 +133,15 @@ export default async ({ strapi }) => {
 
       if (refreshCache) await cacheService.clear({ ...context.params, status, contentType: context.uid })
 
-      if (useCache || returnDeeplyPopulated) {
+      if (returnDeeplyPopulated) {
         const deepPopulate = await populateService.get({ contentType: context.uid, documentId, status, locale })
-        if (returnDeeplyPopulated)
-          return await strapi
-            .documents(context.uid)
-            .findOne({ documentId, status, locale, fields: originalFields, populate: deepPopulate })
+        return await strapi
+          .documents(context.uid)
+          .findOne({ documentId, status, locale, fields: originalFields, populate: deepPopulate })
+      }
+
+      if (useCache && warmOnWrite) {
+        await populateService.get({ contentType: context.uid, documentId, status, locale })
       }
     }
 

--- a/server/src/services/cache.ts
+++ b/server/src/services/cache.ts
@@ -4,9 +4,9 @@ import get from "lodash/get"
 import isEmpty from "lodash/isEmpty"
 import isEqual from "lodash/isEqual"
 
+import type { Config } from "../config"
 import type { PopulateParams } from "./populate"
 
-import type { Config } from "../config"
 import { isUniqueConstraintError } from "../utils/isUniqueConstraintError"
 import log from "../utils/log"
 import { majorMinorVersion } from "../utils/version"

--- a/server/src/services/cache.ts
+++ b/server/src/services/cache.ts
@@ -6,6 +6,7 @@ import isEqual from "lodash/isEqual"
 
 import type { PopulateParams } from "./populate"
 
+import type { Config } from "../config"
 import { isUniqueConstraintError } from "../utils/isUniqueConstraintError"
 import log from "../utils/log"
 import { majorMinorVersion } from "../utils/version"
@@ -102,7 +103,9 @@ export default ({ strapi }: { strapi: Core.Strapi }) => ({
     if (deleted.count !== entries.length)
       console.error(`Deleted count ${deleted.count} does not match entries count ${entries.length}`)
 
-    // Then, in batches, re-populate the entries
+    const { cacheOptions } = strapi.config.get("plugin::deep-populate") as Config
+    if (cacheOptions?.warmOnWrite !== true) return
+
     const batchSize = 5
     for (let i = 0; i < entries.length; i += batchSize) {
       const batch = entries.slice(i, i + batchSize)


### PR DESCRIPTION
Add `cacheOptions.warmOnWrite` config flag. Controls if the cache should
immediately warm after invalidation.

This significantly speeds up publish/update operations when `useCache`
is enabled, at the cost of the first read after a write paying the
cache-miss cost.

Related #154 